### PR TITLE
Added TLS/SSL Support For All GoP2P Network Communications (RPC, Commonnet)

### DIFF
--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -36,7 +36,7 @@ type Variable struct {
 }
 
 // NewTerminal - attempts to start io handler for term commands
-func NewTerminal(rpcPort uint) error {
+func NewTerminal(rpcPort uint, rpcAddress string) error {
 	reader := bufio.NewScanner(os.Stdin) // Init reader
 
 	transport := &http.Transport{ // Init transport
@@ -63,19 +63,19 @@ func NewTerminal(rpcPort uint) error {
 				continue
 			}
 
-			handleCommand(receiver, methodname, params, rpcPort, transport) // Handle command
+			handleCommand(receiver, methodname, params, rpcPort, rpcAddress, transport) // Handle command
 		}
 	}
 }
 
-func handleCommand(receiver string, methodname string, params []string, rpcPort uint, transport *http.Transport) {
-	nodeClient := nodeProto.NewNodeProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init node client
-	handlerClient := handlerProto.NewHandlerProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})             // Init handler client
-	environmentClient := environmentProto.NewEnvironmentProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport}) // Init environment client
-	upnpClient := upnpProto.NewUpnpProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init upnp client
-	databaseClient := databaseProto.NewDatabaseProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})          // Init database client
-	commonClient := commonProto.NewCommonProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                // Init common client
-	shardClient := shardProto.NewShardProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                   // Init shard client
+func handleCommand(receiver string, methodname string, params []string, rpcPort uint, rpcAddress string, transport *http.Transport) {
+	nodeClient := nodeProto.NewNodeProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init node client
+	handlerClient := handlerProto.NewHandlerProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})             // Init handler client
+	environmentClient := environmentProto.NewEnvironmentProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport}) // Init environment client
+	upnpClient := upnpProto.NewUpnpProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init upnp client
+	databaseClient := databaseProto.NewDatabaseProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})          // Init database client
+	commonClient := commonProto.NewCommonProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                // Init common client
+	shardClient := shardProto.NewShardProtobufClient("https://"+rpcAddress+":"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                   // Init shard client
 
 	switch receiver {
 	case "node":

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -43,14 +43,6 @@ func NewTerminal(rpcPort uint) error {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 
-	nodeClient := nodeProto.NewNodeProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init node client
-	handlerClient := handlerProto.NewHandlerProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})             // Init handler client
-	environmentClient := environmentProto.NewEnvironmentProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport}) // Init environment client
-	upnpClient := upnpProto.NewUpnpProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init upnp client
-	databaseClient := databaseProto.NewDatabaseProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})          // Init database client
-	commonClient := commonProto.NewCommonProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                // Init common client
-	shardClient := shardProto.NewShardProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                   // Init shard client
-
 	for {
 		fmt.Print("\n> ") // Print prompt
 
@@ -60,57 +52,73 @@ func NewTerminal(rpcPort uint) error {
 
 		input = strings.TrimSuffix(input, "\n") // Trim newline
 
-		receiver, methodname, params, err := common.ParseStringMethodCall(input) // Attempt to parse as method call
+		err := handleStringOnly(input) // Handle nil-call
+
+		if err != nil {
+			receiver, methodname, params, err := common.ParseStringMethodCall(input) // Attempt to parse as method call
+
+			if err != nil { // Check for errors
+				fmt.Println(err.Error()) // Log found error
+
+				continue
+			}
+
+			handleCommand(receiver, methodname, params, rpcPort, transport) // Handle command
+		}
+	}
+}
+
+func handleCommand(receiver string, methodname string, params []string, rpcPort uint, transport *http.Transport) {
+	nodeClient := nodeProto.NewNodeProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init node client
+	handlerClient := handlerProto.NewHandlerProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})             // Init handler client
+	environmentClient := environmentProto.NewEnvironmentProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport}) // Init environment client
+	upnpClient := upnpProto.NewUpnpProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                      // Init upnp client
+	databaseClient := databaseProto.NewDatabaseProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})          // Init database client
+	commonClient := commonProto.NewCommonProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                // Init common client
+	shardClient := shardProto.NewShardProtobufClient("https://localhost:"+strconv.Itoa(int(rpcPort)), &http.Client{Transport: transport})                   // Init shard client
+
+	switch receiver {
+	case "node":
+		err := handleNode(&nodeClient, methodname, params) // Handle node
 
 		if err != nil { // Check for errors
-			fmt.Println(err.Error()) // Log found error
-
-			continue
+			fmt.Println("\n" + err.Error()) // Log found error
 		}
+	case "handler":
+		err := handleHandler(&handlerClient, methodname, params) // Handle handler
 
-		switch receiver {
-		case "node":
-			err := handleNode(&nodeClient, methodname, params) // Handle node
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
+		}
+	case "environment":
+		err := handleEnvironment(&environmentClient, methodname, params) // Handle environment
 
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "handler":
-			err := handleHandler(&handlerClient, methodname, params) // Handle handler
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
+		}
+	case "upnp":
+		err := handleUpnp(&upnpClient, methodname, params) // Handle upnp
 
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "environment":
-			err := handleEnvironment(&environmentClient, methodname, params) // Handle environment
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
+		}
+	case "database":
+		err := handleDatabase(&databaseClient, methodname, params) // Handle database
 
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "upnp":
-			err := handleUpnp(&upnpClient, methodname, params) // Handle upnp
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
+		}
+	case "common":
+		err := handleCommon(&commonClient, methodname, params) // Handle common
 
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "database":
-			err := handleDatabase(&databaseClient, methodname, params) // Handle database
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
+		}
+	case "shard":
+		err := handleShard(&shardClient, methodname, params) // Handle shard
 
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "common":
-			err := handleCommon(&commonClient, methodname, params) // Handle common
-
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
-		case "shard":
-			err := handleShard(&shardClient, methodname, params) // Handle shard
-
-			if err != nil { // Check for errors
-				fmt.Println("\n" + err.Error()) // Log found error
-			}
+		if err != nil { // Check for errors
+			fmt.Println("\n" + err.Error()) // Log found error
 		}
 	}
 }
@@ -534,12 +542,19 @@ func hasVariableSet(command string) bool {
 	return false
 }
 
-func handle(input string) {
+func handleStringOnly(input string) error {
 	if input == "despacito" || input == "ree" {
 		for x := 0; x != 10000; x++ {
-			color.Red("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")
-			color.Green("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")
-			color.Blue("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")
+			color.Red("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")       // Log string
+			color.Yellow("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")    // Log string
+			color.HiMagenta("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree") // Log string
+			color.Green("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")     // Log string
+			color.Cyan("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")      // Log string
+			color.Blue("Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree Ree")      // Log string
 		}
+
+		return nil // No error occurred, return nil
 	}
+
+	return errors.New("not string call")
 }

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -413,7 +413,7 @@ func handleShard(shardClient *shardProto.Shard, methodname string, params []stri
 	reflectParams = append(reflectParams, reflect.ValueOf(context.Background())) // Append request context
 
 	switch methodname {
-	case "NewShard", "QueryForAddress", "LogShard":
+	case "NewShard", "LogShard":
 		if len(params) != 2 { // Check for invalid parameters length
 			return errors.New("invalid parameters (requires string, string)") // Return error
 		}
@@ -449,6 +449,12 @@ func handleShard(shardClient *shardProto.Shard, methodname string, params []stri
 		port, _ := strconv.Atoi(params[1]) // Fetch int val
 
 		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{Address: params[0], Port: uint32(port), Bytes: []byte(strings.Join(params[2:len(params)], " "))})) // Append params
+	case "QueryForAddress":
+		if len(params) < 3 { // Check for invalid parameters length
+			return errors.New("invalid parameters (require string, string, string)") // Return error
+		}
+
+		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{NetworkName: params[0], Addresses: params[1:len(params)]})) // Append params
 	default:
 		return errors.New("illegal method: " + methodname + ", available methods: NewShard(), NewShardWithNodes(), Shard(), QueryForAddress(), LogShard(), CalculateQuadraticExponent(), SendBytesShardResult(), SendBytesShard()") // Return error
 	}

--- a/cli/terminal.go
+++ b/cli/terminal.go
@@ -378,13 +378,13 @@ func handleCommon(commonClient *commonProto.Common, methodname string, params []
 		reflectParams = append(reflectParams, reflect.ValueOf(&commonProto.GeneralRequest{Inputs: params})) // Append params
 	case "Sha3":
 		if len(params) != 1 { // Check for invalid parameters
-			return errors.New("invalid parameters (requires string)")
+			return errors.New("invalid parameters (requires string)") // Return error
 		}
 
 		reflectParams = append(reflectParams, reflect.ValueOf(&commonProto.GeneralRequest{ByteInput: []byte(params[0])})) // Append params
 	case "SendBytes":
 		if len(params) != 2 { // Check for invalid parameters
-			return errors.New("invalid parameters (requires []byte, string)")
+			return errors.New("invalid parameters (requires []byte, string)") // Return error
 		}
 
 		reflectParams = append(reflectParams, reflect.ValueOf(&commonProto.GeneralRequest{ByteInput: []byte(params[0]), Input: params[1]})) // Append params
@@ -414,18 +414,38 @@ func handleShard(shardClient *shardProto.Shard, methodname string, params []stri
 
 	switch methodname {
 	case "NewShard", "QueryForAddress", "LogShard":
+		if len(params) != 2 { // Check for invalid parameters length
+			return errors.New("invalid parameters (requires string, string)") // Return error
+		}
+
 		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{NetworkName: params[0], Address: params[1]})) // Append params
 	case "NewShardWithNodes":
+		if len(params) < 2 { // Check for invalid parameters length
+			return errors.New("invalid parameters (requires string, []string)") // Return error
+		}
+
 		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{NetworkName: params[0], Addresses: params[1:len(params)]})) // Append params
 	case "Shard":
+		if len(params) != 3 { // Check for invalid parameters length
+			return errors.New("invalid parameters (requires string, string, uint32)") // Return error
+		}
+
 		exponent, _ := strconv.Atoi(params[2]) // Fetch int val
 
-		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{NetworkName: params[0], Address: params[0], Exponent: uint32(exponent)})) // Append params
+		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{NetworkName: params[0], Address: params[1], Exponent: uint32(exponent)})) // Append params
 	case "CalculateQuadraticExponent":
+		if len(params) != 1 { // Check for invalid parameters length
+			return errors.New("invalid parameters (requires uint32)") // Return error
+		}
+
 		exponent, _ := strconv.Atoi(params[0]) // Fetch int val
 
 		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{Exponent: uint32(exponent)})) // Append params
 	case "SendBytesShardResult", "SendBytesShard":
+		if len(params) < 3 { // Check for invalid parameters length
+			return errors.New("invalid parameters (requires string, uint32, []byte)") // Return error
+		}
+
 		port, _ := strconv.Atoi(params[1]) // Fetch int val
 
 		reflectParams = append(reflectParams, reflect.ValueOf(&shardProto.GeneralRequest{Address: params[0], Port: uint32(port), Bytes: []byte(strings.Join(params[2:len(params)], " "))})) // Append params

--- a/common/common.go
+++ b/common/common.go
@@ -54,6 +54,19 @@ var (
 	BEGIN EXPORTED METHODS:
 */
 
+// DelaySeconds - wait until duration passed, return true once duration completed
+func DelaySeconds(seconds uint) bool {
+	startTime := time.Now() // Get current time
+
+	for {
+		if time.Now().Sub(startTime) >= time.Duration(seconds)*time.Second { // Check passed duration
+			break // Break
+		}
+	}
+
+	return true // Reached end
+}
+
 // GetCommonByteDifference - attempt to fetch most similar byte array in array of byte arrays
 func GetCommonByteDifference(b [][]byte) ([]byte, error) {
 	if len(b) == 0 { // Check for nil input

--- a/common/common.go
+++ b/common/common.go
@@ -299,11 +299,11 @@ func Sha3(b []byte) string {
 func SafeSlice(b []byte) string {
 	strVal := string(b) // Convert to string
 
-	if len(strVal) < 20 { // Check for large string
+	if len(strVal) < 30 { // Check for large string
 		return strVal // Safe, return string
 	}
 
-	return strVal[0:20] // Unsafe, return sliced
+	return strVal[0:30] // Unsafe, return sliced
 }
 
 // StringInSlice - check if value is in slice

--- a/common/common.go
+++ b/common/common.go
@@ -268,7 +268,7 @@ func GetExtIPAddrWithoutUPnP() (string, error) {
 
 	close(finished) // Close channel
 
-	return getNonNilInStringSlice(addresses), nil // Return valid address
+	return getNonNilInStringSlice(addresses) // Return valid address
 }
 
 // GetCurrentTime - get current time in the UTC format
@@ -449,7 +449,10 @@ func getIPFromProviderAsync(provider string, buffer *[]string, finished chan boo
 		resp, err := http.Get(provider) // Attempt to check IP via provider
 
 		if err != nil { // Check for errors
-			fmt.Println(err.Error()) // Log error
+			if len(*buffer) == 0 { // Double check IP not already determined
+				*buffer = append(*buffer, "") // Set IP
+				finished <- true              // Set finished
+			}
 		} else {
 			defer resp.Body.Close() // Close connection
 
@@ -477,14 +480,14 @@ func publicKey(privateKey interface{}) interface{} {
 	}
 }
 
-func getNonNilInStringSlice(slice []string) string {
+func getNonNilInStringSlice(slice []string) (string, error) {
 	for _, entry := range slice { // Iterate through entries
 		if entry != "" { // Check for non-nil entry
-			return entry // Return valid entry
+			return entry, nil // Return valid entry
 		}
 	}
 
-	return "" // Couldn't find valid address, return nil
+	return "", fmt.Errorf("couldn't find non-nil element in slice %v", slice) // Couldn't find valid address, return error
 }
 
 /*

--- a/common/common.go
+++ b/common/common.go
@@ -5,6 +5,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
@@ -41,6 +42,12 @@ const (
 var (
 	// ExtIPProviders - preset macro defining list of available external IP checking services
 	ExtIPProviders = []string{"http://checkip.amazonaws.com/", "http://icanhazip.com/", "http://www.trackip.net/ip", "http://bot.whatismyipaddress.com/", "https://ipecho.net/plain", "http://myexternalip.com/raw"}
+
+	// GeneralTLSConfig - general global GoP2P TLS Config
+	GeneralTLSConfig = &tls.Config{ // Init TLS config
+		Certificates:       []tls.Certificate{getTLSCerts("GoP2PGeneral")},
+		InsecureSkipVerify: true,
+		ServerName:         "localhost"}
 )
 
 /*
@@ -381,6 +388,19 @@ func generateTLSCert(privateKey *ecdsa.PrivateKey, namePrefix string) error {
 	}
 
 	return nil // No error occurred, return nil
+}
+
+// getTLSCert - attempt to read TLS cert from current dir
+func getTLSCerts(certPrefix string) tls.Certificate {
+	GenerateTLSCertificates(certPrefix) // Generate certs
+
+	cert, err := tls.LoadX509KeyPair(fmt.Sprintf("%sCert.pem", certPrefix), fmt.Sprintf("%sKey.pem", certPrefix)) // Load key pair
+
+	if err != nil { // Check for errors
+		panic(err) // Panic
+	}
+
+	return cert // Return read certificates
 }
 
 /*

--- a/common/commonnet.go
+++ b/common/commonnet.go
@@ -2,8 +2,10 @@ package common
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"strconv"
@@ -16,7 +18,7 @@ import (
 
 // SendBytes - attempt to send specified bytes to given address
 func SendBytes(b []byte, address string) error {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return err // Return found error
@@ -39,7 +41,7 @@ func SendBytes(b []byte, address string) error {
 
 // SendBytesResult - attempt to send specified bytes to given address, returning result
 func SendBytesResult(b []byte, address string) ([]byte, error) {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return nil, err // Return found error
@@ -70,7 +72,7 @@ func SendBytesResult(b []byte, address string) ([]byte, error) {
 
 // SendBytesAsync - attempt to send specified bytes to given address in an asynchronous manner
 func SendBytesAsync(b []byte, address string, finished []bool) error {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return err // Return found error
@@ -99,7 +101,7 @@ func SendBytesAsync(b []byte, address string, finished []bool) error {
 
 // SendBytesAsyncRoutine - attempt to send specified bytes to given address in an asynchronous, go routine-based manner.
 func SendBytesAsyncRoutine(b []byte, address string, finished chan bool) error {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return err // Return found error
@@ -124,7 +126,7 @@ func SendBytesAsyncRoutine(b []byte, address string, finished chan bool) error {
 
 // SendBytesResultBufferAsync - attempt to send specified bytes to given address in an asynchronous fashion, reading the result into a given buffer
 func SendBytesResultBufferAsync(b []byte, buffer [][]byte, address string, finished chan []bool) error {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return err // Return found error
@@ -160,7 +162,7 @@ func SendBytesResultBufferAsync(b []byte, buffer [][]byte, address string, finis
 }
 
 // SendBytesWithConnection - attempt to send specified bytes to given address via given connection
-func SendBytesWithConnection(connection *net.Conn, b []byte) error {
+func SendBytesWithConnection(connection *tls.Conn, b []byte) error {
 	_, err := (*connection).Write(b) // Write to connection
 
 	if err != nil { // Check for errors
@@ -171,8 +173,8 @@ func SendBytesWithConnection(connection *net.Conn, b []byte) error {
 }
 
 // SendBytesReusable - attempt to send specified bytes to given address and return created connection
-func SendBytesReusable(b []byte, address string) (*net.Conn, error) {
-	connection, err := net.Dial("tcp", address) // Connect to given address
+func SendBytesReusable(b []byte, address string) (*tls.Conn, error) {
+	connection, err := tls.Dial("tcp", address, GeneralTLSConfig) // Connect to given address
 
 	if err != nil { // Check for errors
 		return nil, err // Return found error
@@ -184,11 +186,11 @@ func SendBytesReusable(b []byte, address string) (*net.Conn, error) {
 		return nil, err // Return found errors
 	}
 
-	return &connection, nil // No error occurred, return nil
+	return connection, nil // No error occurred, return nil
 }
 
 // ReadConnectionDelim - attempt to read connection until occurrence of standard GoP2P connection delimiter
-func ReadConnectionDelim(conn net.Conn) ([]byte, error) {
+func ReadConnectionDelim(conn *tls.Conn) ([]byte, error) {
 	reader := bufio.NewReader(conn) // Initialize reader
 
 	data, err := reader.ReadBytes(ConnectionDelimiter) // Read until delimiter
@@ -201,7 +203,7 @@ func ReadConnectionDelim(conn net.Conn) ([]byte, error) {
 }
 
 // ReadConnectionAsync - attempt to read entirety of specified connection in an asynchronous fashion, returning data byte value
-func ReadConnectionAsync(conn net.Conn, buffer chan []byte, finished chan bool, err chan error) {
+func ReadConnectionAsync(conn *tls.Conn, buffer chan []byte, finished chan bool, err chan error) {
 	data, readErr := ioutil.ReadAll(conn) // Read connection
 
 	if readErr != nil { // Check for errors
@@ -219,7 +221,55 @@ func ReadConnectionAsync(conn net.Conn, buffer chan []byte, finished chan bool, 
 }
 
 // ReadConnectionWaitAsync - attempt to read from connection in an asynchronous fashion, after waiting for peer to write
-func ReadConnectionWaitAsync(conn net.Conn) ([]byte, error) {
+func ReadConnectionWaitAsync(conn *tls.Conn) ([]byte, error) {
+	data := make(chan []byte) // Init buffer
+	err := make(chan error)   // Init error buffer
+
+	go func(data chan []byte, err chan error) {
+		for {
+			readData := make([]byte, 4096) // Init read buffer
+
+			conn.SetReadDeadline(time.Now().Add(1 * time.Second)) // Set read deadline
+
+			_, readErr := conn.Read(readData) // Read into buffer
+
+			if readErr != nil { // Check for errors
+				if readErr, timeout := readErr.(net.Error); timeout && readErr.Timeout() { // Check for errors
+					fmt.Println("test")
+					fmt.Println(readData)
+					data <- readData // Write read data
+
+					return // Return
+				}
+
+				err <- readErr // Write found error
+
+				return // Return
+			}
+
+			fmt.Println("test2")
+			fmt.Println(readData)
+
+			data <- readData // Write read data
+		}
+	}(data, err)
+
+	ticker := time.Tick(3 * time.Second) // Init ticker
+
+	for { // Continuously read from connection
+		select {
+		case readData := <-data: // Read data from connection
+			return readData, nil // Return read data
+		case readErr := <-err: // Error on read
+			return []byte{}, readErr // Return error
+		case <-ticker: // Timed out
+			return []byte{}, errors.New("timed out") // Return timed out error
+		}
+	}
+}
+
+// ReadConnectionWaitAsyncNoTLS - attempt to read from connection in an asynchronous fashion, after waiting for peer to write
+func ReadConnectionWaitAsyncNoTLS(conn net.Conn) ([]byte, error) {
 	data := make(chan []byte) // Init buffer
 	err := make(chan error)   // Init error buffer
 
@@ -230,7 +280,11 @@ func ReadConnectionWaitAsync(conn net.Conn) ([]byte, error) {
 			_, readErr := conn.Read(readData) // Read into buffer
 
 			if readErr != nil { // Check for errors
-				err <- readErr // Write found error
+				if readErr != io.EOF { // Set error
+					err <- readErr // Write found error
+				} else {
+					data <- readData // Write read data
+				}
 
 				return // Return
 			}

--- a/common/commonnet_test.go
+++ b/common/commonnet_test.go
@@ -1,13 +1,13 @@
 package common
 
 import (
-	"net"
+	"crypto/tls"
 	"testing"
 )
 
 // TestSendBytes - test functionality of SendBytes() method
 func TestSendBytes(t *testing.T) {
-	err := SendBytes([]byte("test"), "1.1.1.1:80") // Write to address
+	err := SendBytes([]byte("test"), "1.1.1.1:443") // Write to address
 
 	if err != nil { // Check for errors
 		t.Errorf(err.Error()) // Log found error
@@ -19,14 +19,14 @@ func TestSendBytes(t *testing.T) {
 
 // TestSendBytesWithConnection - test functionality of SendBytesWithConnection() method
 func TestSendBytesWithConnection(t *testing.T) {
-	connection, err := net.Dial("tcp", "1.1.1.1:80") // Init connection
+	connection, err := tls.Dial("tcp", "1.1.1.1:443", GeneralTLSConfig) // Init connection
 
 	if err != nil { // Check for errors
 		t.Errorf(err.Error()) // Log found error
 		t.FailNow()           // Panic
 	}
 
-	err = SendBytesWithConnection(&connection, []byte("test")) // Attempt to send bytes
+	err = SendBytesWithConnection(connection, []byte("test")) // Attempt to send bytes
 
 	if err != nil { // Check for errors
 		t.Errorf(err.Error()) // Log found error
@@ -43,7 +43,7 @@ func TestSendBytesWithConnection(t *testing.T) {
 
 // TestSendBytesReusable - test functionality of SendBytesReusable() method
 func TestSendBytesReusable(t *testing.T) {
-	connection, err := SendBytesReusable([]byte("test"), "1.1.1.1:80") // Attempt to send bytes
+	connection, err := SendBytesReusable([]byte("test"), "1.1.1.1:443") // Attempt to send bytes
 
 	if err != nil { // Check for errors
 		t.Errorf(err.Error()) // Log found error

--- a/main.go
+++ b/main.go
@@ -126,5 +126,4 @@ func startNode() {
 }
 
 /* TODO:
-- test RPC & TCP encryption/decryption reading
-*/
+ */

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func startRPCServer() {
 	mux.Handle(commonProto.CommonPathPrefix, commonHandler)                // Start mux common handler
 	mux.Handle(shardProto.ShardPathPrefix, shardHandler)                   // Start mux shard handler
 
-	go http.ListenAndServeTLS(":"+strconv.Itoa(*rpcPortFlag), "cert.pem", "key.pem", mux) // Start server
+	go http.ListenAndServeTLS(":"+strconv.Itoa(*rpcPortFlag), "gop2pTermCert.pem", "gop2pTermKey.pem", mux) // Start server
 }
 
 // startNode - attempt to execute attachnode, starthandler commands

--- a/main.go
+++ b/main.go
@@ -114,5 +114,5 @@ func startNode() {
 
 /* TODO:
 - add RPC connection encryption
-- switch all references to tls.Conn to tls.conn
+- upgrade handler sockets to async servers
 */

--- a/main.go
+++ b/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/fatih/color"
 	"github.com/mitsukomegumi/GoP2P/cli"
@@ -28,11 +30,12 @@ import (
 )
 
 var (
-	terminalFlag = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                      // Init term flag
-	upnpFlag     = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding") // Init upnp flag
-	rpcPortFlag  = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                 // Init RPC port flag
-	noColorFlag  = flag.Bool("no-color", false, "disables GoP2P terminal colored output")             // Init color flag
-	forwardRPC   = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")  // Init forward RPC flag
+	terminalFlag = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                                                                                   // Init term flag
+	upnpFlag     = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding")                                                              // Init upnp flag
+	rpcPortFlag  = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                                                                              // Init RPC port flag
+	noColorFlag  = flag.Bool("no-color", false, "disables GoP2P terminal colored output")                                                                          // Init color flag
+	forwardRPC   = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")                                                               // Init forward RPC flag
+	rpcAddr      = flag.String("remote-rpc", fmt.Sprintf("localhost:%s", strconv.Itoa(*rpcPortFlag)), "connects to remote RPC terminal (default: localhost:8080)") // Init remote rpc addr flag
 )
 
 func main() {
@@ -46,12 +49,14 @@ func main() {
 		go upnp.ForwardPortSilent(3000) // Forward port 3000
 	} else if *noColorFlag { // Check for no colors
 		color.NoColor = true // Disable colors
+	} else if strings.Contains(*rpcAddr, "localhost") { // Check for default RPC address
+		startRPCServer() // Start RPC server
 	}
 
-	startRPCServer() // Start RPC server
+	if *terminalFlag { // Check for terminal
+		*rpcAddr = strings.Split(*rpcAddr, ":")[0] // Remove port
 
-	if *terminalFlag {
-		cli.NewTerminal(uint(*rpcPortFlag)) // Initialize terminal
+		cli.NewTerminal(uint(*rpcPortFlag), *rpcAddr) // Initialize terminal
 	}
 
 	startNode() // Attempt to start GoP2P in node mode

--- a/main.go
+++ b/main.go
@@ -47,9 +47,13 @@ func main() {
 		}
 
 		go upnp.ForwardPortSilent(3000) // Forward port 3000
-	} else if *noColorFlag { // Check for no colors
+	}
+
+	if *noColorFlag { // Check for no colors
 		color.NoColor = true // Disable colors
-	} else if strings.Contains(*rpcAddr, "localhost") { // Check for default RPC address
+	}
+
+	if strings.Contains(*rpcAddr, "localhost") { // Check for default RPC address
 		startRPCServer() // Start RPC server
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,19 +30,19 @@ import (
 )
 
 var (
-	terminalFlag = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                                                                                   // Init term flag
-	upnpFlag     = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding")                                                              // Init upnp flag
-	rpcPortFlag  = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                                                                              // Init RPC port flag
-	noColorFlag  = flag.Bool("no-color", false, "disables GoP2P terminal colored output")                                                                          // Init color flag
-	forwardRPC   = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")                                                               // Init forward RPC flag
-	rpcAddr      = flag.String("remote-rpc", fmt.Sprintf("localhost:%s", strconv.Itoa(*rpcPortFlag)), "connects to remote RPC terminal (default: localhost:8080)") // Init remote rpc addr flag
+	terminalFlag   = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                                                                                   // Init term flag
+	upnpFlag       = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding")                                                              // Init upnp flag
+	rpcPortFlag    = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                                                                              // Init RPC port flag
+	noColorFlag    = flag.Bool("no-color", false, "disables GoP2P terminal colored output")                                                                          // Init color flag
+	forwardRPCFlag = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")                                                               // Init forward RPC flag
+	rpcAddrFlag    = flag.String("remote-rpc", fmt.Sprintf("localhost:%s", strconv.Itoa(*rpcPortFlag)), "connects to remote RPC terminal (default: localhost:8080)") // Init remote rpc addr flag
 )
 
 func main() {
 	flag.Parse() // Parse flags
 
 	if !*upnpFlag { // Check for UPnP
-		if *forwardRPC {
+		if *forwardRPCFlag {
 			go upnp.ForwardPortSilent(uint(*rpcPortFlag)) // Forward RPC port
 		}
 
@@ -53,14 +53,14 @@ func main() {
 		color.NoColor = true // Disable colors
 	}
 
-	if strings.Contains(*rpcAddr, "localhost") { // Check for default RPC address
+	if strings.Contains(*rpcAddrFlag, "localhost") { // Check for default RPC address
 		startRPCServer() // Start RPC server
 	}
 
 	if *terminalFlag { // Check for terminal
-		*rpcAddr = strings.Split(*rpcAddr, ":")[0] // Remove port
+		*rpcAddrFlag = strings.Split(*rpcAddrFlag, ":")[0] // Remove port
 
-		cli.NewTerminal(uint(*rpcPortFlag), *rpcAddr) // Initialize terminal
+		cli.NewTerminal(uint(*rpcPortFlag), *rpcAddrFlag) // Initialize terminal
 	}
 
 	startNode() // Attempt to start GoP2P in node mode
@@ -126,6 +126,5 @@ func startNode() {
 }
 
 /* TODO:
-- add RPC connection encryption
-- upgrade handler sockets to async servers
+- test RPC & TCP encryption/decryption reading
 */

--- a/main.go
+++ b/main.go
@@ -114,5 +114,5 @@ func startNode() {
 
 /* TODO:
 - add RPC connection encryption
-- switch all references to net.conn to tls.conn
+- switch all references to tls.Conn to tls.conn
 */

--- a/main.go
+++ b/main.go
@@ -32,14 +32,18 @@ var (
 	upnpFlag     = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding") // Init upnp flag
 	rpcPortFlag  = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                 // Init RPC port flag
 	noColorFlag  = flag.Bool("no-color", false, "disables GoP2P terminal colored output")             // Init color flag
+	forwardRPC   = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")  // Init forward RPC flag
 )
 
 func main() {
 	flag.Parse() // Parse flags
 
 	if !*upnpFlag { // Check for UPnP
-		go upnp.ForwardPortSilent(uint(*rpcPortFlag)) // Forward RPC port
-		go upnp.ForwardPortSilent(3000)               // Forward port 3000
+		if *forwardRPC {
+			go upnp.ForwardPortSilent(uint(*rpcPortFlag)) // Forward RPC port
+		}
+
+		go upnp.ForwardPortSilent(3000) // Forward port 3000
 	} else if *noColorFlag { // Check for no colors
 		color.NoColor = true // Disable colors
 	}

--- a/main.go
+++ b/main.go
@@ -30,12 +30,12 @@ import (
 )
 
 var (
-	terminalFlag   = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                                                                                   // Init term flag
-	upnpFlag       = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding")                                                              // Init upnp flag
-	rpcPortFlag    = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                                                                              // Init RPC port flag
-	noColorFlag    = flag.Bool("no-color", false, "disables GoP2P terminal colored output")                                                                          // Init color flag
-	forwardRPCFlag = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")                                                               // Init forward RPC flag
-	rpcAddrFlag    = flag.String("remote-rpc", fmt.Sprintf("localhost:%s", strconv.Itoa(*rpcPortFlag)), "connects to remote RPC terminal (default: localhost:8080)") // Init remote rpc addr flag
+	terminalFlag   = flag.Bool("terminal", false, "launch GoP2P in terminal mode")                                                                                    // Init term flag
+	upnpFlag       = flag.Bool("no-upnp", false, "launch GoP2P without automatic UPnP port forwarding")                                                               // Init upnp flag
+	rpcPortFlag    = flag.Int("rpc-port", 8080, "launch GoP2P with specified RPC port")                                                                               // Init RPC port flag
+	noColorFlag    = flag.Bool("no-color", false, "disables GoP2P terminal colored output")                                                                           // Init color flag
+	forwardRPCFlag = flag.Bool("forward-rpc", false, "enables forwarding of GoP2P RPC terminal ports")                                                                // Init forward RPC flag
+	rpcAddrFlag    = flag.String("rpc-address", fmt.Sprintf("localhost:%s", strconv.Itoa(*rpcPortFlag)), "connects to remote RPC terminal (default: localhost:8080)") // Init remote rpc addr flag
 )
 
 func main() {

--- a/rpc/database/server.go
+++ b/rpc/database/server.go
@@ -113,11 +113,9 @@ func (server *Server) RemoveNode(ctx context.Context, req *databaseProto.General
 	if req.Address == "localhost" { // Check for invalid address
 		address, err := common.GetExtIPAddrWithoutUPnP()
 
-		if err != nil { // Check for errors
-			return &databaseProto.GeneralResponse{}, err // Return found error
+		if err == nil { // Check for errors
+			req.Address = address // Set to request value
 		}
-
-		req.Address = address // Set to request value
 	}
 
 	currentDir, err := common.GetCurrentDir() // Fetch current dir

--- a/rpc/node/server.go
+++ b/rpc/node/server.go
@@ -21,11 +21,9 @@ func (server *Server) NewNode(ctx context.Context, req *nodeProto.GeneralRequest
 	if req.Address == "localhost" { // Check for invalid address
 		address, err := common.GetExtIPAddrWithoutUPnP() // Fetch IP
 
-		if err != nil { // Check for errors
-			return &nodeProto.GeneralResponse{}, err // Return found error
+		if err == nil { // Check for errors
+			req.Address = address // Set to request value
 		}
-
-		req.Address = address // Set to request value
 	}
 
 	node, err := node.NewNode(req.Address, req.IsBootstrap) // Init node

--- a/rpc/shard/server.go
+++ b/rpc/shard/server.go
@@ -60,6 +60,18 @@ func (server *Server) NewShard(ctx context.Context, req *shardProto.GeneralReque
 		return &shardProto.GeneralResponse{}, err // Return found error
 	}
 
+	err = db.WriteToMemory(node.Environment) // Write to memory
+
+	if err != nil { // Check for errors
+		return &shardProto.GeneralResponse{}, err // Return found error
+	}
+
+	err = node.WriteToMemory(currentDir) // Write env to memory
+
+	if err != nil { // Check for errors
+		return &shardProto.GeneralResponse{}, err // Return found error
+	}
+
 	return &shardProto.GeneralResponse{Message: fmt.Sprintf("\n%s", string(marshaledVal))}, nil // Return response
 }
 
@@ -175,7 +187,7 @@ func (server *Server) QueryForAddress(ctx context.Context, req *shardProto.Gener
 		return &shardProto.GeneralResponse{}, err // Return found error
 	}
 
-	shardIndex, err := db.QueryForShardAddress(req.Address) // Query shard by address
+	shardIndex, err := db.QueryForShardAddress(req.Addresses[0]) // Query shard by address
 
 	if err != nil { // Check for errors
 		return &shardProto.GeneralResponse{}, err // Return found error
@@ -183,7 +195,7 @@ func (server *Server) QueryForAddress(ctx context.Context, req *shardProto.Gener
 
 	shard := (*db.Shards)[shardIndex] // Fetch shard by index
 
-	nodeIndex, err := shard.QueryForAddress(req.Address) // Fetch node index
+	nodeIndex, err := shard.QueryForAddress(req.Addresses[1]) // Fetch node index
 
 	if err != nil { // Check for errors
 		return &shardProto.GeneralResponse{}, err // Return found error

--- a/types/connection/connection.go
+++ b/types/connection/connection.go
@@ -95,7 +95,7 @@ func (connection *Connection) AttemptVariable() (*environment.Variable, error) {
 
 // attempt - attempt connection
 func (connection *Connection) attempt() ([]byte, error) {
-	fmt.Println("-- CONNECTION -- attempting connection")
+	fmt.Println("-- CONNECTION -- attempting connection to peer with address " + connection.DestinationNode.Address) // Log connection
 
 	serializedConnection, err := common.SerializeToBytes(*connection) // Serialize connection
 
@@ -108,6 +108,10 @@ func (connection *Connection) attempt() ([]byte, error) {
 	if err != nil { // Check for errors
 		return nil, err // Return found error
 	}
+
+	/*
+		TODO: fix nil read data
+	*/
 
 	return result, nil // No error occurred, return nil
 }

--- a/types/database/database.go
+++ b/types/database/database.go
@@ -167,13 +167,17 @@ func (db *NodeDatabase) QueryForAddress(address string) (uint, error) {
 
 // QueryForShardAddress - attempts to search specified node database for specified address, returning index of shard
 func (db *NodeDatabase) QueryForShardAddress(address string) (uint, error) {
-	for x := 0; x != len(*db.Shards); x++ { // Wait until entire db has been queried
-		if address == (*db.Shards)[x].Address { // Check for match
-			return uint(x), nil // Return matching index
+	if db.Shards != nil {
+		for x := 0; x != len(*db.Shards); x++ { // Wait until entire db has been queried
+			if address == (*db.Shards)[x].Address { // Check for match
+				return uint(x), nil // Return matching index
+			}
 		}
+
+		return 0, errors.New("no value found") // Could not find index of address, return new error
 	}
 
-	return 0, errors.New("no value found") // Could not find index of address, return new error
+	return 0, fmt.Errorf("no shards in db %v", db) // Return no shards error
 }
 
 // UpdateRemoteDatabase - push database changes to remote network nodes

--- a/types/database/database.go
+++ b/types/database/database.go
@@ -136,6 +136,12 @@ func (db *NodeDatabase) AddShard(destinationShard *shard.Shard) error {
 		return err // Return found error
 	}
 
+	err = node.WriteToMemory(currentDir) // Write to memory
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
+
 	return nil // No error occurred, return nil
 }
 
@@ -148,6 +154,36 @@ func (db *NodeDatabase) RemoveShard(address string) error {
 	}
 
 	db.removeShard(int(shardIndex)) // Removes value at index
+
+	err = db.UpdateRemoteDatabase() // Update remote database instances
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
+
+	currentDir, err := common.GetCurrentDir() // Get working directory
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
+
+	node, err := node.ReadNodeFromMemory(currentDir) // Read node from working dir
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
+
+	err = db.WriteToMemory(node.Environment) // Write to local environment
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
+
+	err = node.WriteToMemory(currentDir) // Write to memory
+
+	if err != nil { // Check for errors
+		return err // Return found error
+	}
 
 	return nil // Returns nil, no error
 }

--- a/types/handler/handler.go
+++ b/types/handler/handler.go
@@ -55,7 +55,7 @@ func handleConnection(node *node.Node, conn net.Conn) error {
 		return err // Return found error
 	}
 
-	fmt.Println("\n\n-- CONNECTION " + conn.RemoteAddr().String() + " -- attempted to read " + strconv.Itoa(len(data)) + " byte of data.") // Log read connection
+	fmt.Println("\n\n-- CONNECTION " + conn.RemoteAddr().String() + " -- attempted to read " + strconv.Itoa(len(data)) + " bytes of data.") // Log read connection
 
 	if len(readConnection.ConnectionStack) == 0 { // Check if event stack exists
 		val, isMessage, err := handleSingular(node, readConnection) // Handle singular event
@@ -204,8 +204,8 @@ func handleStack(node *node.Node, connection *connection.Connection) ([][]byte, 
 		responses = append(responses, val) // Append response
 	}
 
-	if len(responses) == 0 {
-		return nil, errors.New("nil response")
+	if len(responses) == 0 { // Check for nil response
+		return nil, errors.New("nil response") // Return found error
 	}
 
 	return responses, nil // No error occurred, return nil

--- a/types/handler/handler.go
+++ b/types/handler/handler.go
@@ -33,7 +33,7 @@ func StartHandler(node *node.Node, ln *net.Listener) error {
 
 // handleConnection - attempt to fetch connection metadata, handle it respectively (stack or singular)
 func handleConnection(node *node.Node, conn net.Conn) error {
-	data, err := common.ReadConnectionWaitAsyncNoTLS(net.Conn(conn)) // Read entire connection
+	data, err := common.ReadConnectionWaitAsyncNoTLS(conn) // Read entire connection
 
 	if err != nil { // Check for errors
 		return err // Return found error
@@ -97,9 +97,9 @@ func handleConnection(node *node.Node, conn net.Conn) error {
 
 	fmt.Println("\n-- CONNECTION " + readConnection.InitializationNode.Address + " -- responding with data " + common.SafeSlice(serializedResponse) + "...") // Log response
 
-	conn.Write(serializedResponse) // Write success
+	_, err = conn.Write(serializedResponse) // Write success
 
-	return nil // Attempt to handle stack
+	return err // Attempt to handle stack
 }
 
 // handleSingular - no stack present in found connection, write variable with connection data

--- a/types/handler/handler.go
+++ b/types/handler/handler.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -26,17 +25,15 @@ func StartHandler(node *node.Node, ln *net.Listener) error {
 	for {
 		conn, err := (*ln).Accept() // Accept connection
 
-		tlsConn := tls.Server(conn, common.GeneralTLSConfig) // Accept tls conn
-
 		if err == nil { // Check for errors
-			go handleConnection(node, tlsConn) // Handle connection
+			go handleConnection(node, conn) // Handle connection
 		}
 	}
 }
 
 // handleConnection - attempt to fetch connection metadata, handle it respectively (stack or singular)
-func handleConnection(node *node.Node, conn *tls.Conn) error {
-	data, err := common.ReadConnectionWaitAsync(conn) // Read entire connection
+func handleConnection(node *node.Node, conn net.Conn) error {
+	data, err := common.ReadConnectionWaitAsyncNoTLS(net.Conn(conn)) // Read entire connection
 
 	if err != nil { // Check for errors
 		return err // Return found error

--- a/types/node/node.go
+++ b/types/node/node.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -55,7 +56,7 @@ func NewNode(address string, isBootstrap bool) (Node, error) {
 
 // StartListener - attempt to listen on specified port, return new listener
 func (node *Node) StartListener(port int) (*net.Listener, error) {
-	ln, err := net.Listen("tcp", ":"+strconv.Itoa(port)) // Listen on port
+	ln, err := tls.Listen("tcp", ":"+strconv.Itoa(port), common.GeneralTLSConfig) // Listen on port
 
 	if err != nil { // Check for errors
 		return nil, err // Return found error


### PR DESCRIPTION
- [x] Swap out all net.Conn references for tls.Conn
- [x] Add TLS, SSL support for RPC+commonnet TCP operations
- [x] Add SSL cert, key generation methods in common.go
- [x] Automatically generate necessary keys and certs in main.go
- [x] Specify default GoP2P tls connection config in common.go
- [x] Default RPC operations to https rather than http
- [x] Add remote RPC terminal address, forward RPC flags (rpc-address, forward-rpc)
- [x] Add shard package RPC terminal support
- [x] Update remote database on addition or deletion of shards from db
- [x] Fix commonnet ReadConnectionWaitAsync, ReadConnectionWaitAsyncNoTLS timing issues, inclusion of nil buffer chars in response